### PR TITLE
Fix:close_controller

### DIFF
--- a/app/controllers/closes_controller.rb
+++ b/app/controllers/closes_controller.rb
@@ -6,9 +6,7 @@ class ClosesController < ApplicationController
     @post.status = @post.closed? ? :closing : :published
 
     if @post.valid?
-      Post.transaction do
-        @post.save!
-      end
+      @post.save
 
       flash[:notice] = @post.message_on_closing
 


### PR DESCRIPTION
## 概要
`closes_controller`の`update`アクション内のtransaction処理が不要であったので、その処理の削除。この処理が入っていたのは、検索したコードをコピペしたためだと思われる。