### PR TITLE
Fix:deadline_error

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,7 @@ class Post < ApplicationRecord
     validates :title
     validates :body
     validates :status
+    validates :deadline
   end
 
   enum status: { published: 0, draft: 1, closing: 2, trash: 3, untrash: 4 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -31,9 +31,16 @@
     <%= f.label :status %> </br>
     <%= f.collection_radio_buttons :status, Post.statuses_i18n.slice(:published, :draft), :first , :last %>
   </div>
-  <div class="form-group">
-    <%= f.label :deadline %>
-    <%= f.datetime_field :deadline, class: 'form-control', rows: 10 %>
-  </div>
+  <% if post.deadline.blank? %>
+    <div class="form-group">
+      <%= f.label :deadline %>
+      <%= f.datetime_field :deadline, class: 'form-control', min: Date.today, value: Time.current.since(1.week).strftime('%Y-%m-%dT12:00') %>
+    </div>
+  <% else %>
+    <div class="form-group">
+      <%= f.label :deadline %>
+      <%= f.datetime_field :deadline, class: 'form-control', min: Date.today %>
+    </div>
+  <% end %>
   <%= f.submit (t 'defaults.register'), class: "btn btn-primary", name: 'commit' %>
 <% end %>


### PR DESCRIPTION
## 概要
投稿に関して、新規投稿の際に締め切りが空でも投稿できてしまう欠陥があり、さらに一つでも空の投稿があれば投稿一覧が表示できなくなるという重大なインシデントがあった。そのため空での投稿ができないようにバリデーションの追加、また初期値が入力されるように修正した。

そのほか、理由が不明だが新規投稿の際バリデーションに引っかかってrenderした際に、 `……posts/new` ではなく `……posts`になり、その状態でページの再読み込みをすると投稿一覧のページに飛んでしまう現象を確認した。